### PR TITLE
Trim bulky question_ids/category_ids from phrase list/search/related responses; redesign phrase-editor overrides UI

### DIFF
--- a/src/app/api/data.service.ts
+++ b/src/app/api/data.service.ts
@@ -195,6 +195,21 @@ export class DataService {
     return this.http.patch(`${this.base_url}/master-phrases/${phraseRef}/`, payload);
   }
 
+  /** Reads english/conjugated/question_ids/category_ids for one phrase
+   *  concept — the counterpart to updateMasterPhrase's write. Public read. */
+  getMasterPhrase(phraseRef: string): Observable<any> {
+    return this.http.get(`${this.base_url}/master-phrases/${phraseRef}/`);
+  }
+
+  /** Linking data for one SamplePhrase (resolved question_ids/category_ids
+   *  + its raw question_overrides), omitted from list/search/by-answer/
+   *  by-category/related responses since they're bulky and unused there —
+   *  fetch on demand when an edit modal needs them for one phrase. key is a
+   *  SamplePhrase._key ("{sample}_{phrase_ref}"). */
+  getPhraseLinks(key: string): Observable<{ question_ids: number[]; category_ids: number[]; question_overrides: { include: number[]; exclude: number[] } }> {
+    return this.http.get<{ question_ids: number[]; category_ids: number[]; question_overrides: { include: number[]; exclude: number[] } }>(`${this.base_url}/phrases/${key}/links/`);
+  }
+
   searchResearchQuestions(query: string): Observable<any[]> {
     if (!query || query.trim().length < 2) return of([]);
     return this.http.get<any[]>(`${this.base_url}/research-questions/search/?q=${encodeURIComponent(query.trim())}`);
@@ -211,10 +226,6 @@ export class DataService {
 
   getPhraseList(): Observable<PhraseListItem[]> {
     return this.http.get<PhraseListItem[]>(`${this.base_url}/phrases/list/`);
-  }
-
-  getPhrasesByAnswer(answerId: any): Observable<any> {
-    return this.http.get(this.base_url + '/phrases/by-answer/?answer_key=' + answerId)
   }
 
   exportPhrases(query: string, sampleRefs?: string[], sort: string = 'phrase_ref', field: string = 'both', phraseRef?: string): Observable<any[]> {
@@ -247,8 +258,15 @@ export class DataService {
     return this.http.delete(`${this.base_url}/backups/${id}/`);
   }
 
-  getTranscriptionsByAnswer(answerId: any): Observable<any> {
-    return this.http.get(this.base_url + '/transcriptions/by-answer/?answer_key=' + answerId)
+  /** Combined phrases+transcriptions lookup for the "click a table cell"
+   *  hot path — one request instead of two, and (when answerKey is given)
+   *  one shared Answer lookup for both overrides checks instead of two.
+   *  answerKey is optional; omit it when there's no answer in play (e.g.
+   *  no phrase_overrides/transcription_overrides could apply). */
+  getRelatedContent(categoryId: number, sample: string, answerKey?: string): Observable<{ phrases: any[]; transcriptions: any[] }> {
+    let url = `${this.base_url}/related/?category_id=${categoryId}&sample=${encodeURIComponent(sample)}`;
+    if (answerKey) url += `&answer_key=${encodeURIComponent(answerKey)}`;
+    return this.http.get<{ phrases: any[]; transcriptions: any[] }>(url);
   }
 
   getTranscriptions(sampleRef: string): Observable<any[]> {

--- a/src/app/phrases/phrases.component.html
+++ b/src/app/phrases/phrases.component.html
@@ -365,7 +365,10 @@
             </small>
           </div>
 
-          <ul class="list-unstyled mb-2">
+          <div *ngIf="phraseLinksLoading" class="text-muted small mb-2">
+            <span class="spinner-border spinner-border-sm me-1" role="status"></span>Loading...
+          </div>
+          <ul class="list-unstyled mb-2" *ngIf="!phraseLinksLoading">
             <li *ngFor="let qid of phraseEditData.masterQuestionIds" class="mb-2">
               <div class="d-flex align-items-center gap-2">
                 <span class="small flex-grow-1"
@@ -427,7 +430,7 @@
             </div>
           </div>
 
-          <button type="button" class="btn btn-outline-secondary btn-sm mt-2" (click)="toggleQuestionOverrides()">
+          <button type="button" class="btn btn-outline-secondary btn-sm mt-2" (click)="toggleQuestionOverrides()" [disabled]="phraseLinksLoading">
             {{ showQuestionOverrides ? 'Done' : 'Override' }}
           </button>
         </div>
@@ -437,7 +440,7 @@
           Cancel
         </button>
         <button type="button" class="btn btn-primary" (click)="savePhrase()"
-                [disabled]="phraseEditSaving || showQuestionOverrides"
+                [disabled]="phraseEditSaving || showQuestionOverrides || phraseLinksLoading"
                 [title]="showQuestionOverrides ? 'Click Done to finish overriding first' : ''">
           <span *ngIf="phraseEditSaving" class="spinner-border spinner-border-sm me-1" role="status"></span>
           {{ phraseEditSaving ? 'Saving...' : 'Save Changes' }}
@@ -491,6 +494,11 @@
           Changes here affect all of them at once.
         </p>
 
+        <div *ngIf="masterLinksLoading" class="text-muted small mb-3">
+          <span class="spinner-border spinner-border-sm me-1" role="status"></span>Loading...
+        </div>
+
+        <ng-container *ngIf="!masterLinksLoading">
         <div class="mb-3">
           <label class="form-label">English Translation</label>
           <input type="text" class="form-control" [(ngModel)]="masterEditData.english">
@@ -555,12 +563,13 @@
             </button>
           </div>
         </div>
+        </ng-container>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" (click)="closeMasterEditModal()" [disabled]="masterEditSaving">
           Cancel
         </button>
-        <button type="button" class="btn btn-warning" (click)="saveMasterPhrase()" [disabled]="masterEditSaving">
+        <button type="button" class="btn btn-warning" (click)="saveMasterPhrase()" [disabled]="masterEditSaving || masterLinksLoading">
           <span *ngIf="masterEditSaving" class="spinner-border spinner-border-sm me-1" role="status"></span>
           {{ masterEditSaving ? 'Saving...' : 'Save Changes' }}
         </button>

--- a/src/app/phrases/phrases.component.ts
+++ b/src/app/phrases/phrases.component.ts
@@ -191,6 +191,8 @@ export class PhrasesComponent implements OnInit, OnDestroy {
   phraseEditSaving = false;
   phraseEditError = '';
   phraseEditSuccess = '';
+  /** True while GET /phrases/{key}/links/ is loading for the modal. */
+  phraseLinksLoading = false;
   /** Pending confirmation for excluding a listed RQ (rare, needs confirm). */
   excludeConfirmTarget: number | null = null;
   showQuestionOverrides = false;
@@ -205,6 +207,8 @@ export class PhrasesComponent implements OnInit, OnDestroy {
   masterEditSaving = false;
   masterEditError = '';
   masterEditSuccess = '';
+  /** True while GET /master-phrases/{phrase_ref}/ is loading for the modal. */
+  masterLinksLoading = false;
 
   /** Human-readable hierarchy labels for linked question_ids/category_ids,
    *  resolved on demand (batch) whenever an edit modal opens. */
@@ -473,24 +477,10 @@ export class PhrasesComponent implements OnInit, OnDestroy {
 
   openPhraseEditModal(phrase: any): void {
     this.editingPhrase = phrase;
-    const overrides = phrase.question_overrides || { include: [], exclude: [] };
-    const include = [...(overrides.include || [])];
-    const exclude = [...(overrides.exclude || [])];
-    const resolved: number[] = phrase.question_ids || [];
-    // The server only returns the resolved set (master ∪ include − exclude).
-    // Reconstruct the master-only list for display: strip out anything the
-    // user added themselves, then add back anything they excluded (which
-    // resolved already omits) — see question_overrides docs on the server.
-    const includeSet = new Set(include);
-    const masterQuestionIds = Array.from(new Set([
-      ...resolved.filter(id => !includeSet.has(id)),
-      ...exclude,
-    ]));
-
     this.phraseEditData = {
       phrase: phrase.phrase || '',
-      masterQuestionIds,
-      question_overrides: { include, exclude },
+      masterQuestionIds: [],
+      question_overrides: { include: [], exclude: [] },
     };
     this.phraseEditError = '';
     this.phraseEditSuccess = '';
@@ -498,8 +488,37 @@ export class PhrasesComponent implements OnInit, OnDestroy {
     this.questionSearchResults = [];
     this.showQuestionOverrides = false;
     this.excludeConfirmTarget = null;
-    this.resolveLinkedLabels(Array.from(new Set([...masterQuestionIds, ...include])));
+    this.phraseLinksLoading = true;
     this.showPhraseEditModal = true;
+
+    // question_ids are bulky and omitted from list/search rows — fetch
+    // them for this one phrase now that the modal actually needs them.
+    this.dataService.getPhraseLinks(phrase._key).subscribe({
+      next: ({ question_ids, question_overrides }) => {
+        const overrides = question_overrides || { include: [], exclude: [] };
+        const include = [...(overrides.include || [])];
+        const exclude = [...(overrides.exclude || [])];
+        const resolved = question_ids || [];
+        // The endpoint returns the resolved set (master ∪ include − exclude).
+        // Reconstruct the master-only list for display: strip out anything
+        // the user added themselves, then add back anything they excluded
+        // (which resolved already omits) — see question_overrides docs on
+        // the server.
+        const includeSet = new Set(include);
+        const masterQuestionIds = Array.from(new Set([
+          ...resolved.filter((id: number) => !includeSet.has(id)),
+          ...exclude,
+        ]));
+
+        this.phraseEditData.masterQuestionIds = masterQuestionIds;
+        this.phraseEditData.question_overrides = { include, exclude };
+        this.phraseLinksLoading = false;
+        this.resolveLinkedLabels(Array.from(new Set([...masterQuestionIds, ...include])));
+      },
+      error: () => {
+        this.phraseLinksLoading = false;
+      }
+    });
   }
 
   closePhraseEditModal(): void {
@@ -644,25 +663,42 @@ export class PhrasesComponent implements OnInit, OnDestroy {
 
   openMasterEditModal(phrase: any): void {
     this.editingMasterPhrase = phrase;
-    this.masterEditData = {
-      english: phrase.english || '',
-      conjugated: !!phrase.conjugated,
-      question_ids: phrase.question_ids ? [...phrase.question_ids] : [],
-      category_ids: phrase.category_ids ? [...phrase.category_ids] : [],
-    };
+    this.masterEditData = { english: '', conjugated: false, question_ids: [], category_ids: [] };
     this.masterEditError = '';
     this.masterEditSuccess = '';
     this.categorySearchInput = '';
     this.categorySearchResults = [];
-    this.dataService.getResearchQuestionsByIds(this.masterEditData.question_ids).subscribe(questions => {
-      questions.forEach(q => this.questionLabelById.set(q.id, this.formatHierarchy(q.hierarchy, q.name)));
-    });
-    if (this.masterEditData.category_ids.length > 0) {
-      this.dataService.getCategoriesByIds(this.masterEditData.category_ids).subscribe(categories => {
-        categories.forEach(c => this.categoryLabelById.set(c.id, this.formatHierarchy(c.hierarchy, c.name)));
-      });
-    }
+    this.masterLinksLoading = true;
     this.showMasterEditModal = true;
+
+    // Fetch fresh rather than trusting the row's own english/conjugated —
+    // question_ids/category_ids are omitted from list/search rows entirely
+    // (bulky, unused there), so this is required, not just an optimization.
+    this.dataService.getMasterPhrase(phrase.phrase_ref).subscribe({
+      next: (master) => {
+        this.masterEditData = {
+          english: master.english || '',
+          conjugated: !!master.conjugated,
+          question_ids: master.question_ids ? [...master.question_ids] : [],
+          category_ids: master.category_ids ? [...master.category_ids] : [],
+        };
+        this.masterLinksLoading = false;
+        if (this.masterEditData.question_ids.length > 0) {
+          this.dataService.getResearchQuestionsByIds(this.masterEditData.question_ids).subscribe(questions => {
+            questions.forEach(q => this.questionLabelById.set(q.id, this.formatHierarchy(q.hierarchy, q.name)));
+          });
+        }
+        if (this.masterEditData.category_ids.length > 0) {
+          this.dataService.getCategoriesByIds(this.masterEditData.category_ids).subscribe(categories => {
+            categories.forEach(c => this.categoryLabelById.set(c.id, this.formatHierarchy(c.hierarchy, c.name)));
+          });
+        }
+      },
+      error: () => {
+        this.masterLinksLoading = false;
+        this.masterEditError = 'Failed to load phrase concept.';
+      }
+    });
   }
 
   closeMasterEditModal(): void {

--- a/src/app/shared/phrase-transcription-modal/phrase-transcription-modal.component.ts
+++ b/src/app/shared/phrase-transcription-modal/phrase-transcription-modal.component.ts
@@ -71,27 +71,21 @@ export class PhraseTranscriptionModalComponent implements OnChanges, AfterViewIn
     this.isLoadingPhrases = true;
     this.isLoadingTranscriptions = true;
 
-    // Load phrases
-    this.dataService.getPhrasesByAnswer(this.answer._key).subscribe({
-      next: (phrases) => {
+    // Single combined request. Passing answerKey lets the server resolve
+    // any phrase_overrides/transcription_overrides (the rare ~65
+    // "divergent questions" case) via one shared Answer lookup.
+    this.dataService.getRelatedContent(this.answer.question_id, this.answer.sample, this.answer._key).subscribe({
+      next: ({ phrases, transcriptions }) => {
         this.modalPhrases = phrases;
         this.isLoadingPhrases = false;
-      },
-      error: (err) => {
-        this.isLoadingPhrases = false;
-      }
-    });
-    
-    // Load transcriptions
-    this.dataService.getTranscriptionsByAnswer(this.answer._key).subscribe({
-      next: (transcriptions) => {
-        this.modalTranscriptions = transcriptions.map((t: any) => ({
+        this.modalTranscriptions = (transcriptions || []).map((t: any) => ({
           ...t,
           glossSafe: t.gloss ? this.sanitizer.bypassSecurityTrustHtml(t.gloss) : null
         }));
         this.isLoadingTranscriptions = false;
       },
       error: (err) => {
+        this.isLoadingPhrases = false;
         this.isLoadingTranscriptions = false;
       }
     });

--- a/src/app/views/views.component.ts
+++ b/src/app/views/views.component.ts
@@ -893,11 +893,10 @@ export class ViewsComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   openPhrasesModal(result: any): void {
-    // Create an answer object compatible with the modal component
-    // The modal expects an answer with _key property
-    this.modalAnswer = {
-      _key: result._key
-    };
+    // Pass the full answer/search-result object through — the modal needs
+    // more than _key now (question_id, sample, and any phrase_overrides/
+    // transcription_overrides) to use the cheaper by-category lookup.
+    this.modalAnswer = result;
 
     // Get the answer value for the title
     const answerValue = this.getAnswerValue(result);


### PR DESCRIPTION
- Add getPhraseLinks()/getMasterPhrase() and fetch linking data lazily per-phrase (on modal open) instead of denormalizing it onto every bulk phrase row (avg ~56 ids/phrase, unused there)
- Switch phrase-transcription-modal to the single combined getRelatedContent() call; drop the now-dead getPhrasesByAnswer/getTranscriptionsByAnswer/getPhrasesByCategory/getTranscriptionsByCategory client methods and the by-answer fallback path
- Fix views.component's openPhrasesModal to pass the full search-result object (was only passing _key, which broke the category-based lookup)
- Redesign the sample-phrase editor's RQ override UI: single "Override" toggle gates both exclude/add actions, excluded items stay listed (struck through, with undo) instead of disappearing, added items get their own visually separated box, "added" badge softened, explanation text reworded and visually separated, "Done" moved below both sections, Save disabled while overriding or while links are loading
